### PR TITLE
Defining undefined fgColors for Python and others

### DIFF
--- a/Solarized (Dark).xml
+++ b/Solarized (Dark).xml
@@ -159,7 +159,7 @@ Credits:
         <LexerType name="objc" desc="Objective-C" ext="">
             <WordsStyle name="DIRECTIVE" styleID="19" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="DEFAULT" styleID="11" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="QUALIFIER" styleID="20" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="QUALIFIER" styleID="20" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="9" fgColor="B58900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="D11C24" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="TYPE WORD" styleID="16" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
@@ -271,10 +271,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="2" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HEADER" styleID="3" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="POSITION" styleID="4" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DELETED" styleID="5" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ADDED" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="HEADER" styleID="3" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="POSITION" styleID="4" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DELETED" styleID="5" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ADDED" styleID="6" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="nfo" desc="Dos Style" ext="">
             <WordsStyle name="DEFAULT" styleID="32" fgColor="819090" bgColor="042029" />
@@ -285,8 +285,8 @@ Credits:
             <WordsStyle name="PREPROCESSOR" styleID="2" fgColor="B58900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="3" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TARGET" styleID="5" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IDEOL" styleID="9" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="TARGET" styleID="5" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IDEOL" styleID="9" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="vb" desc="VB / VBS" ext="">
             <WordsStyle name="DEFAULT" styleID="7" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -341,9 +341,9 @@ Credits:
             <WordsStyle name="HASH" styleID="14" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="SYMBOL TABLE" styleID="15" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="PUNCTUATION" styleID="8" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="LONGQUOTE" styleID="19" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="DATASECTION" styleID="21" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="REGSUBST" styleID="18" fgColor="D30102" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="BACKTICKS" styleID="20" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -355,10 +355,10 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="4" fgColor="3EABA0" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="KEYWORDS" styleID="5" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="TRIPLE" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CLASSNAME" styleID="8" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DEFNAME" styleID="9" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="TRIPLE" styleID="6" fgColor="6c71c4" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="TRIPLEDOUBLE" styleID="7" fgColor="6c71c4" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CLASSNAME" styleID="8" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DEFNAME" styleID="9" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="11" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="12" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -386,14 +386,14 @@ Credits:
             <WordsStyle name="STRING" styleID="6" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="7" fgColor="3EABA0" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNC1" styleID="13" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNC2" styleID="14" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="FUNC3" styleID="15" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="FUNC1" styleID="13" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNC2" styleID="14" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNC3" styleID="15" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
         </LexerType>
         <LexerType name="tex" desc="TeX" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="1" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="GROUP" styleID="2" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="1" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="GROUP" styleID="2" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="3" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="4" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="TEXT" styleID="5" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -407,16 +407,16 @@ Credits:
             <WordsStyle name="FUNCTION" styleID="5" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="VARIABLE" styleID="6" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="LABEL" styleID="7" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
             <WordsStyle name="SECTION" styleID="9" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SUBSECTION" styleID="10" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IF DEFINE" styleID="11" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="12" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SUBSECTION" styleID="10" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IF DEFINE" styleID="11" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="12" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING VAR" styleID="13" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAGE EX" styleID="16" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SECTION GROUP" styleID="15" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PAGE EX" styleID="16" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="FUNCTION DEFINITIONS" styleID="17" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="18" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="actionscript" desc="ActionScript" ext="">
@@ -443,7 +443,7 @@ Credits:
         </LexerType>
         <LexerType name="bash" desc="bash" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="4" fgColor="D11C24" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING" styleID="5" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -452,10 +452,10 @@ Credits:
             <WordsStyle name="IDENTIFIER" styleID="8" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="SCALAR" styleID="9" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PARAM" styleID="10" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PARAM" styleID="10" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="BACKTICKS" styleID="11" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HERE DELIM" styleID="12" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="HERE Q" styleID="13" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="HERE DELIM" styleID="12" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="HERE Q" styleID="13" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="fortran" desc="Fortran" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -467,24 +467,24 @@ Credits:
             <WordsStyle name="OPERATOR" styleID="6" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="7" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="8" fgColor="D11C24" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="FUNCTION1" styleID="9" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="FUNCTION2" styleID="10" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="FUNCTION1" styleID="9" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="FUNCTION2" styleID="10" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="B58900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="OPERATOR2" styleID="12" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="OPERATOR2" styleID="12" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="LABEL" styleID="13" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CONTINUATION" styleID="14" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CONTINUATION" styleID="14" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="lisp" desc="LISP" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="1" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="2" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="FUNCTION WORD" styleID="3" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="SYMBOL" styleID="5" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING" styleID="6" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="8" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="9" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="10" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="SPECIAL" styleID="11" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="11" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="12" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="asm" desc="Assembler" ext="">
@@ -494,21 +494,21 @@ Credits:
             <WordsStyle name="STRING" styleID="3" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="4" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="5" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="REGISTER" styleID="8" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="CPU INSTRUCTION" styleID="6" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
+            <WordsStyle name="MATH INSTRUCTION" styleID="7" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="REGISTER" styleID="8" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
             <WordsStyle name="COMMENT BLOCK" styleID="11" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="12" fgColor="3EABA0" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRINGEOL" styleID="13" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXT INSTRUCTION" styleID="14" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
         </LexerType>
         <LexerType name="ruby" desc="Ruby" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ERROR" styleID="1" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ERROR" styleID="1" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="2" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="POD" styleID="3" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="POD" styleID="3" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="5" fgColor="738A05" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="STRING" styleID="6" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -520,26 +520,26 @@ Credits:
             <WordsStyle name="REGEX" styleID="12" fgColor="D30102" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="13" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="14" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MODULE NAME" styleID="15" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MODULE NAME" styleID="15" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTANCE VAR" styleID="16" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CLASS VAR" styleID="17" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CLASS VAR" styleID="17" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="BACKTICKS" styleID="18" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DATA SECTION" styleID="19" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DATA SECTION" styleID="19" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING Q" styleID="24" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="postscript" desc="Postscript" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DSC VALUE" styleID="3" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DSC COMMENT" styleID="2" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DSC VALUE" styleID="3" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="Name" styleID="5" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="Name" styleID="5" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="6" fgColor="738A05" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="LITERAL" styleID="7" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IMMEVAL" styleID="8" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAREN DICT" styleID="10" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="PAREN PROC" styleID="11" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="LITERAL" styleID="7" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IMMEVAL" styleID="8" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PAREN ARRAY" styleID="9" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PAREN DICT" styleID="10" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PAREN PROC" styleID="11" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="TEXT" styleID="12" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="HEX STRING" styleID="13" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="BASE85 STRING" styleID="14" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -555,14 +555,14 @@ Credits:
             <WordsStyle name="IDENTIFIER" styleID="6" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="7" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION" styleID="8" fgColor="738A05" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="STD OPERATOR" styleID="9" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="ATTRIBUTE" styleID="10" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="DIRECTIVE" styleID="9" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="STD TYPE" styleID="13" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="USER DEFINE" styleID="14" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="DIRECTIVE OPERAND" styleID="10" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="STD FUNCTION" styleID="11" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="STD PACKAGE" styleID="12" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
+            <WordsStyle name="STD TYPE" styleID="13" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="USER DEFINE" styleID="14" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
         </LexerType>
         <LexerType name="smalltalk" desc="Smalltalk" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -570,27 +570,27 @@ Credits:
             <WordsStyle name="NUMBER" styleID="2" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="3" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="SYMBOL" styleID="4" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BINARY" styleID="5" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="BOOL" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SELF" styleID="7" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SUPER" styleID="8" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="NIL" styleID="9" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="BINARY" styleID="5" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="BOOL" styleID="6" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SELF" styleID="7" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SUPER" styleID="8" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="NIL" styleID="9" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="GLOBAL" styleID="10" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="RETURN" styleID="11" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="KWS END" styleID="13" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ASSIGN" styleID="14" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="RETURN" styleID="11" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="KWS END" styleID="13" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ASSIGN" styleID="14" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="15" fgColor="3EABA0" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL SELECTOR" styleID="16" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="caml" desc="Caml" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="IDENTIFIER" styleID="1" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="TAGNAME" styleID="2" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="3" fgColor="D11C24" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="TYPE" styleID="5" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="LINENUM" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="BUILIN FUNC &amp; TYPE" styleID="4" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="TYPE" styleID="5" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="LINENUM" styleID="6" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="7" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="8" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="9" fgColor="3EABA0" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -614,19 +614,19 @@ Credits:
             <WordsStyle name="COMMENT LINE" styleID="2" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT LINE BANG" styleID="3" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="12" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER" styleID="19" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="USER" styleID="19" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="kix" desc="KiXtart" ext="">
             <!--
-            <WordsStyle name="" styleID="0" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="" styleID="0" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         -->
             <WordsStyle name="DEFAULT" styleID="31" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING" styleID="2" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING2" styleID="3" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="4" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="VAR" styleID="5" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
+            <WordsStyle name="VAR" styleID="5" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="7" fgColor="D11C24" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="FUNCTION" styleID="8" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="OPERATOR" styleID="9" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -638,29 +638,29 @@ Credits:
             <WordsStyle name="NUMBER" styleID="3" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="FUNCTION" styleID="4" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
             <WordsStyle name="INSTRUCTION WORD" styleID="5" fgColor="D11C24" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="MACRO" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="MACRO" styleID="6" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="STRING" styleID="7" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="8" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="9" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="SENT" styleID="10" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
+            <WordsStyle name="SENT" styleID="10" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
             <WordsStyle name="PREPROCESSOR" styleID="11" fgColor="B58900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
-            <WordsStyle name="SPECIAL" styleID="12" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
-            <WordsStyle name="EXPAND" styleID="13" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
-            <WordsStyle name="COMOBJ" styleID="14" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="SPECIAL" styleID="12" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
+            <WordsStyle name="EXPAND" styleID="13" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type5" />
+            <WordsStyle name="COMOBJ" styleID="14" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="ada" desc="ADA" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="INSTRUCTION WORD" styleID="1" fgColor="D11C24" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="IDENTIFIER" styleID="2" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="3" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DELIMITER" styleID="4" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DELIMITER" styleID="4" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="3EABA0" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CHARACTER EOL" styleID="6" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING" styleID="7" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING EOL" styleID="8" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="LABEL" styleID="9" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT LINE" styleID="10" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="ILLEGAL" styleID="11" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="ILLEGAL" styleID="11" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>
         <LexerType name="matlab" desc="Matlab" ext="">
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -681,12 +681,12 @@ Credits:
             <WordsStyle name="STRING" styleID="4" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CHARACTER" styleID="5" fgColor="3EABA0" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="CLASS" styleID="6" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MODULE" styleID="7" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="CAPITAL" styleID="8" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="DATA" styleID="9" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IMPORT" styleID="10" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MODULE" styleID="7" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="CAPITAL" styleID="8" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="DATA" styleID="9" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IMPORT" styleID="10" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="OPERATOR" styleID="11" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="INSTANCE" styleID="12" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="INSTANCE" styleID="12" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTLINE" styleID="13" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK" styleID="14" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENTBLOCK2" styleID="15" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
@@ -696,10 +696,10 @@ Credits:
             <WordsStyle name="DEFAULT" styleID="0" fgColor="819090" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="KEYWORD" styleID="2" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre2" />
-            <WordsStyle name="PARAMETER" styleID="3" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="PARAMETER" styleID="3" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
             <WordsStyle name="SECTION" styleID="4" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
             <WordsStyle name="PREPROCESSOR" styleID="5" fgColor="B58900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type2" />
-            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PREPROCESSOR INLINE" styleID="6" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMENT PASCAL" styleID="7" fgColor="93A1A1" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="KEYWORD PASCAL" styleID="8" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type3" />
             <WordsStyle name="KEYWORD USER" styleID="9" fgColor="859900" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type4" />
@@ -714,13 +714,13 @@ Credits:
             <WordsStyle name="STRING L" styleID="3" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING R" styleID="4" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="COMMAND" styleID="5" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="instre1" />
-            <WordsStyle name="PARAMETER" styleID="6" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="PARAMETER" styleID="6" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="VARIABLE" styleID="7" fgColor="268BD2" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="USER DEFINED" styleID="8" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
-            <WordsStyle name="WHILEDEF" styleID="9" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="IFDEF" styleID="11" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
-            <WordsStyle name="MACRODEF" styleID="12" fgColor="" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="USER DEFINED" styleID="8" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" keywordClass="type1" />
+            <WordsStyle name="WHILEDEF" styleID="9" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="FOREACHDEF" styleID="10" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="IFDEF" styleID="11" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
+            <WordsStyle name="MACRODEF" styleID="12" fgColor="839496" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="STRING VARIABLE" styleID="13" fgColor="269186" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
             <WordsStyle name="NUMBER" styleID="14" fgColor="D33682" bgColor="042029" fontName="" fontStyle="" fontSize="10" />
         </LexerType>


### PR DESCRIPTION
Proposed changes per #3 :

For Python, I've set CLASSNAME and DEFNAME to `blue`/268BD2, i.e. the same as IDENTIFIER, as this appears to be in-line with what Solarized for vim does. 

Python's TRIPLE and TRIPLEDOUBLE effectively serve as either constants or comments in Python depending on context, so there doesn't seem to be much consensus on styling. I've made the somewhat-arbitrary decision to use `magenta` for these as it's not used for anything else in Python currently.

All of the other undefined selectors I just changed to `base0`, as I don't have language samples or familiarity to test the rest. I'm fairly confident this will at least be an improvement on the default black in all cases.