### PR TITLE
Issue 5 - Selected text is nearly unperceivable in Light theme

### DIFF
--- a/Solarized (Light).xml
+++ b/Solarized (Light).xml
@@ -755,7 +755,7 @@ Credits:
         <WidgetStyle name="Bad brace colour" styleID="35" fgColor="EF2929" bgColor="FDF6E3" fontName="" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Current line background colour" styleID="0" bgColor="FDF7E6" />
         <WidgetStyle name="Mark colour" styleID="0" fgColor="CC0000" bgColor="EDD400" />
-        <WidgetStyle name="Selected text colour" styleID="0" bgColor="FDF8E9" />
+        <WidgetStyle name="Selected text colour" styleID="0" bgColor="EEE8D5" />
         <WidgetStyle name="Caret colour" styleID="2069" fgColor="000000" />
         <WidgetStyle name="Find Mark Style" styleID="31" fgColor="CC0000" bgColor="EDD400" fontName="" fontStyle="0" fontSize="10" />
         <WidgetStyle name="Edge colour" styleID="0" fgColor="EEEEEC" />


### PR DESCRIPTION
Updated Solarized (Light).xml "Selected text colour" to bgColor="EEE8D5"