### PR TITLE
Add color to "URL hovered".

### DIFF
--- a/Solarized (Dark).xml
+++ b/Solarized (Dark).xml
@@ -771,5 +771,6 @@ Credits:
         <WidgetStyle name="Active tab unfocused indicator" styleID="0" fgColor="F57900" />
         <WidgetStyle name="Active tab text" styleID="0" fgColor="2E3436" />
         <WidgetStyle name="Inactive tabs" styleID="0" fgColor="555753" bgColor="BABDB6" />
+        <WidgetStyle name="URL hovered" styleID="0" fgColor="F1FA8C" bgColor="282A36" fontStyle="0" />
     </GlobalStyles>
 </NotepadPlus>


### PR DESCRIPTION
Hi walesmd, 

I really like the solarized theme, thank you very much.

With the solarized (dark) style, and I notice that when the mouse hover on a link, the foreground color of the link will turn blue (0000ff) which is similar to the background color (002836).

So I choose a little brighter foreground (fgColor="F1FA8C" bgColor="282A36") for the style of "URL hovered".

Please check it, i would be very glad to see this commit is adopted.

You did it great, thanks for your time.

  Best wishes.

    Tom